### PR TITLE
feat: support Mysql From Schemas

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -27,6 +27,7 @@
         "commander": "^14.0.1",
         "drizzle-dbml-generator": "^0.10.0",
         "hono": "^4.10.1",
+        "node-sql-parser": "^5.3.13",
         "open": "^10.2.0",
         "pg": "^8.16.3",
         "picocolors": "^1.1.1",
@@ -657,6 +658,8 @@
 
     "@types/node": ["@types/node@22.18.11", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-Gd33J2XIrXurb+eT2ktze3rJAfAp9ZNjlBdh4SVgyrKEOADwCbdUDaK7QgJno8Ue4kcajscsKqu6n8OBG3hhCQ=="],
 
+    "@types/pegjs": ["@types/pegjs@0.10.6", "", {}, "sha512-eLYXDbZWXh2uxf+w8sXS8d6KSoXTswfps6fvCUuVAGN8eRpfe7h9eSRydxiSJvo9Bf+GzifsDOr9TMQlmJdmkw=="],
+
     "@types/phoenix": ["@types/phoenix@1.6.6", "", {}, "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A=="],
 
     "@types/react": ["@types/react@19.2.2", "", { "dependencies": { "csstype": "^3.0.2" } }, "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA=="],
@@ -770,6 +773,8 @@
     "basic-auth": ["basic-auth@2.0.1", "", { "dependencies": { "safe-buffer": "5.1.2" } }, "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg=="],
 
     "better-path-resolve": ["better-path-resolve@1.0.0", "", { "dependencies": { "is-windows": "^1.0.0" } }, "sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g=="],
+
+    "big-integer": ["big-integer@1.6.52", "", {}, "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg=="],
 
     "bippy": ["bippy@0.3.31", "", { "dependencies": { "@types/react-reconciler": "^0.28.9" }, "peerDependencies": { "react": ">=17.0.1" } }, "sha512-cCYVokhbNiU3jneh73xBfxm192ZUmJp+sx4A0n7rFxmwwBiUYNavaHorW3A2w0174IPaGBjJJtQNiOBOetoY7A=="],
 
@@ -1312,6 +1317,8 @@
     "node-fetch-native": ["node-fetch-native@1.6.7", "", {}, "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q=="],
 
     "node-releases": ["node-releases@2.0.25", "", {}, "sha512-4auku8B/vw5psvTiiN9j1dAOsXvMoGqJuKJcR+dTdqiXEK20mMTk1UEo3HS16LeGQsVG6+qKTPM9u/qQ2LqATA=="],
+
+    "node-sql-parser": ["node-sql-parser@5.3.13", "", { "dependencies": { "@types/pegjs": "^0.10.0", "big-integer": "^1.6.48" } }, "sha512-heyWv3lLjKHpcBDMUSR+R0DohRYZTYq+Ro3hJ4m9Ia8ccdKbL5UijIaWr2L4co+bmmFuvBVZ4v23QW2PqvBFAA=="],
 
     "normalize-package-data": ["normalize-package-data@5.0.0", "", { "dependencies": { "hosted-git-info": "^6.0.0", "is-core-module": "^2.8.1", "semver": "^7.3.5", "validate-npm-package-license": "^3.0.4" } }, "sha512-h9iPVIfrVZ9wVYQnxFgtw1ugSvGEMOlyPWWtm8BMJhnwyEL/FLbYbTY3V3PpjI/BUK67n9PEWDu6eHzu1fB15Q=="],
 

--- a/packages/core/mysql/school.sql
+++ b/packages/core/mysql/school.sql
@@ -1,0 +1,185 @@
+-- School Management System Database Schema
+
+-- Drop tables if they exist (in reverse order of dependencies)
+DROP TABLE IF EXISTS exam_results;
+DROP TABLE IF EXISTS attendance;
+DROP TABLE IF EXISTS enrollments;
+DROP TABLE IF EXISTS courses;
+DROP TABLE IF EXISTS teachers;
+DROP TABLE IF EXISTS students;
+DROP TABLE IF EXISTS departments;
+DROP TABLE IF EXISTS classes;
+DROP TABLE IF EXISTS users;
+
+-- Users table (for authentication)
+CREATE TABLE users (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  email VARCHAR(255) NOT NULL UNIQUE,
+  password_hash VARCHAR(255) NOT NULL,
+  role ENUM('admin', 'teacher', 'student', 'parent') NOT NULL,
+  is_active BOOLEAN DEFAULT TRUE,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
+-- Departments table
+CREATE TABLE departments (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(100) NOT NULL UNIQUE,
+  description TEXT,
+  head_teacher_id INT,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
+-- Classes/Grades table
+CREATE TABLE classes (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(50) NOT NULL,
+  grade_level INT NOT NULL,
+  section VARCHAR(10),
+  academic_year VARCHAR(20) NOT NULL,
+  max_students INT DEFAULT 30,
+  room_number VARCHAR(20),
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  UNIQUE KEY unique_class (grade_level, section, academic_year)
+);
+
+-- Students table
+CREATE TABLE students (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  user_id INT NOT NULL UNIQUE,
+  student_number VARCHAR(50) NOT NULL UNIQUE,
+  first_name VARCHAR(100) NOT NULL,
+  last_name VARCHAR(100) NOT NULL,
+  date_of_birth DATE NOT NULL,
+  gender ENUM('male', 'female', 'other') NOT NULL,
+  address TEXT,
+  phone VARCHAR(20),
+  parent_name VARCHAR(200),
+  parent_phone VARCHAR(20),
+  parent_email VARCHAR(255),
+  enrollment_date DATE NOT NULL,
+  class_id INT,
+  status ENUM('active', 'suspended', 'graduated', 'withdrawn') DEFAULT 'active',
+  photo_url VARCHAR(255),
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+  FOREIGN KEY (class_id) REFERENCES classes(id) ON DELETE SET NULL
+);
+
+-- Teachers table
+CREATE TABLE teachers (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  user_id INT NOT NULL UNIQUE,
+  employee_number VARCHAR(50) NOT NULL UNIQUE,
+  first_name VARCHAR(100) NOT NULL,
+  last_name VARCHAR(100) NOT NULL,
+  date_of_birth DATE NOT NULL,
+  gender ENUM('male', 'female', 'other') NOT NULL,
+  address TEXT,
+  phone VARCHAR(20) NOT NULL,
+  qualification VARCHAR(200),
+  specialization VARCHAR(200),
+  hire_date DATE NOT NULL,
+  department_id INT,
+  salary DECIMAL(10, 2),
+  status ENUM('active', 'on_leave', 'resigned', 'retired') DEFAULT 'active',
+  photo_url VARCHAR(255),
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+  FOREIGN KEY (department_id) REFERENCES departments(id) ON DELETE SET NULL
+);
+
+-- Add foreign key for department head
+ALTER TABLE departments 
+  ADD FOREIGN KEY (head_teacher_id) REFERENCES teachers(id) ON DELETE SET NULL;
+
+-- Courses/Subjects table
+CREATE TABLE courses (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  code VARCHAR(20) NOT NULL UNIQUE,
+  name VARCHAR(200) NOT NULL,
+  description TEXT,
+  credits INT DEFAULT 1,
+  department_id INT,
+  teacher_id INT,
+  class_id INT,
+  schedule VARCHAR(100),
+  academic_year VARCHAR(20) NOT NULL,
+  semester ENUM('1', '2', 'summer') NOT NULL,
+  max_students INT DEFAULT 35,
+  is_active BOOLEAN DEFAULT TRUE,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  FOREIGN KEY (department_id) REFERENCES departments(id) ON DELETE SET NULL,
+  FOREIGN KEY (teacher_id) REFERENCES teachers(id) ON DELETE SET NULL,
+  FOREIGN KEY (class_id) REFERENCES classes(id) ON DELETE SET NULL
+);
+
+-- Enrollments table (students enrolled in courses)
+CREATE TABLE enrollments (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  student_id INT NOT NULL,
+  course_id INT NOT NULL,
+  enrollment_date DATE NOT NULL DEFAULT (CURRENT_DATE),
+  status ENUM('enrolled', 'completed', 'dropped', 'failed') DEFAULT 'enrolled',
+  final_grade DECIMAL(5, 2),
+  grade_letter VARCHAR(2),
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  FOREIGN KEY (student_id) REFERENCES students(id) ON DELETE CASCADE,
+  FOREIGN KEY (course_id) REFERENCES courses(id) ON DELETE CASCADE,
+  UNIQUE KEY unique_enrollment (student_id, course_id)
+);
+
+-- Attendance table
+CREATE TABLE attendance (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  student_id INT NOT NULL,
+  course_id INT NOT NULL,
+  date DATE NOT NULL,
+  status ENUM('present', 'absent', 'late', 'excused') NOT NULL,
+  notes TEXT,
+  marked_by INT,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  FOREIGN KEY (student_id) REFERENCES students(id) ON DELETE CASCADE,
+  FOREIGN KEY (course_id) REFERENCES courses(id) ON DELETE CASCADE,
+  FOREIGN KEY (marked_by) REFERENCES teachers(id) ON DELETE SET NULL,
+  UNIQUE KEY unique_attendance (student_id, course_id, date)
+);
+
+-- Exam Results table
+CREATE TABLE exam_results (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  enrollment_id INT NOT NULL,
+  exam_type ENUM('quiz', 'midterm', 'final', 'assignment', 'project') NOT NULL,
+  exam_name VARCHAR(200) NOT NULL,
+  exam_date DATE NOT NULL,
+  max_score DECIMAL(5, 2) NOT NULL,
+  score DECIMAL(5, 2) NOT NULL,
+  percentage DECIMAL(5, 2) GENERATED ALWAYS AS ((score / max_score) * 100) STORED,
+  grade_letter VARCHAR(2),
+  notes TEXT,
+  graded_by INT,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  FOREIGN KEY (enrollment_id) REFERENCES enrollments(id) ON DELETE CASCADE,
+  FOREIGN KEY (graded_by) REFERENCES teachers(id) ON DELETE SET NULL,
+  INDEX idx_enrollment_exam (enrollment_id, exam_date)
+);
+
+-- Create indexes for better query performance
+CREATE INDEX idx_students_class ON students(class_id);
+CREATE INDEX idx_students_status ON students(status);
+CREATE INDEX idx_teachers_department ON teachers(department_id);
+CREATE INDEX idx_courses_teacher ON courses(teacher_id);
+CREATE INDEX idx_courses_class ON courses(class_id);
+CREATE INDEX idx_enrollments_student ON enrollments(student_id);
+CREATE INDEX idx_enrollments_course ON enrollments(course_id);
+CREATE INDEX idx_attendance_date ON attendance(date);
+CREATE INDEX idx_attendance_student ON attendance(student_id);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -62,6 +62,7 @@
     "commander": "^14.0.1",
     "drizzle-dbml-generator": "^0.10.0",
     "hono": "^4.10.1",
+    "node-sql-parser": "^5.3.13",
     "open": "^10.2.0",
     "pg": "^8.16.3",
     "picocolors": "^1.1.1",

--- a/packages/core/src/cmd/schema-path-suggestions.ts
+++ b/packages/core/src/cmd/schema-path-suggestions.ts
@@ -19,6 +19,10 @@ export const schemaPathSuggestions = (db: DatabaseType) => {
 			schemaPromptMessage = "Enter the TypeORM entities directory or config path";
 			defaultSchemaPath = "src/entities/";
 			break;
+		case "mysql":
+			schemaPromptMessage = "Enter the MySQL schema directory path";
+			defaultSchemaPath = "db/schema/";
+			break;
 	}
 
 	return {

--- a/packages/core/src/cmd/select-db.ts
+++ b/packages/core/src/cmd/select-db.ts
@@ -10,7 +10,7 @@ export const selectDB = async (): Promise<DatabaseType> => {
 			{ value: "drizzle", label: "Drizzle" },
 			{ value: "typeorm", label: "TypeORM" },
 			{ value: "postgres", label: "PostgreSQL", hint: "coming soon" },
-			{ value: "mysql", label: "MySQL", hint: "coming soon" },
+			{ value: "mysql", label: "MySQL"},
 			{ value: "sqlite", label: "SQLite", hint: "coming soon" },
 		],
 	});
@@ -19,8 +19,8 @@ export const selectDB = async (): Promise<DatabaseType> => {
 		return process.exit(0);
 	}
 
-	if (["postgres", "mysql", "sqlite"].includes(databaseType)) {
-		cancel(`${databaseType} is not supported yet. Please use Drizzle, Prisma, or TypeORM.`);
+	if (["postgres", "sqlite"].includes(databaseType)) {
+		cancel(`${databaseType} is not supported yet. Please use Drizzle, Prisma, TypeORM or MySQL.`);
 		return process.exit(0);
 	}
 

--- a/packages/core/src/generators/gen-mysql-erd.ts
+++ b/packages/core/src/generators/gen-mysql-erd.ts
@@ -1,0 +1,176 @@
+import { readFile } from "node:fs/promises";
+import type { Edge, ErdResult, Field, Node } from "../types/erd.type";
+import { calcTableWidth } from "../utils/calc-table-width";
+import { Parser } from "node-sql-parser/build/mysql";
+import { getFilesFromDir } from "../utils/get-files-from-dir";
+
+
+export const genMySQLERD = async (schemaPath: string): Promise<ErdResult> => {
+  
+  const files = await getFilesFromDir([".sql"], schemaPath)
+
+  if (files.length === 0) {
+    throw new Error(`No SQL schema files found at ${schemaPath}`);
+  }
+
+  const schemaContents = await Promise.all(files.map((file) => readFile(file, "utf-8")));
+
+  const schemaContent = schemaContents.join("\n");
+
+  const parser = new Parser();
+  const parsedSchema = parser.astify(schemaContent, { database: "MySQL" });
+
+  // For debugging purposes
+  // writeFile("parsedSchema.json", JSON.stringify(parsedSchema,null,2), ()=>{});
+
+  if (!Array.isArray(parsedSchema) || parsedSchema.length === 0) {
+    throw new Error("No tables found in the schema");
+  }
+
+  const nodes: Node[] = [];
+  const edges: Edge[] = [];
+  const relationshipMap = new Map<string, Array<{ targetTable: string; targetColumn: string; fieldIndex: number }>>();
+
+  // First pass: Create nodes with all scalar fields
+  parsedSchema.forEach((ast) => {
+
+    let fields: Field[] = [];
+    let fieldIndex = 0;
+
+    if (ast.type !== "create" || ast.create_definitions == null || ast.keyword !== 'table' || ast.table === null) return;
+
+    let tableName = "";
+
+    if(Array.isArray(ast.table))
+    {
+      tableName = ast.table[0]?.table ?? "";
+    }else {
+      tableName = ast.table?.table ?? "";
+    }
+    // Process each column
+    ast.create_definitions.forEach((definition, idx) => {
+
+      if (definition.resource === "column") 
+      {
+        if (definition.column.type !== 'column_ref') return;
+        const newdefinition = definition as typeof definition & { primary_key?: "primary key" | "key"};
+        let IsID = newdefinition.primary_key === "primary key";
+        let IsUnique = definition.unique === 'unique';
+        ast.create_definitions?.forEach((def) => {
+          if(def.resource === 'constraint' && def.constraint_type === 'primary key')
+          {
+            def.definition.forEach(column => {
+              if(column.type !== 'column_ref' || definition.column.type !== 'column_ref') return;
+              if(column.column === definition.column.column)
+              {
+                IsID = true;
+              }
+            });
+          }
+          else if (def.resource === 'constraint' && (def.constraint_type === 'unique' || def.constraint_type === 'unique index'))
+          {
+            def.definition.forEach(column => {
+              if(column.type !== 'column_ref' || definition.column.type !== 'column_ref') return;
+              if(column.column === definition.column.column)
+              {
+                IsUnique = true;
+              }
+            });
+          }
+        });
+
+        let fieldLabel = definition.column.column as string;
+
+        // Determine type with additional info
+        let typeDisplay = definition.definition.dataType.toUpperCase();
+        if (definition.definition.length) {
+          typeDisplay += `(${definition.definition.length})`;
+        }
+
+        fields.push({
+          name: definition.column.column as string,
+          type: typeDisplay,
+          isId: IsID,
+          isUnique: IsUnique,
+          isList: false,
+          kind: "scalar",
+          label: fieldLabel,
+          isNullable: definition.nullable?.type === 'null'
+        });
+
+        fieldIndex++;
+      }
+      else if(definition.resource === "constraint" && definition.constraint_type === 'FOREIGN KEY')
+      {
+        if(definition.definition[0]?.type !== 'column_ref' ) return;
+        let sourceTable = tableName;
+        let TargetTable = definition.reference_definition?.table[0].table as string;
+        let sourceColumn = definition.definition[0]?.column as string;
+        let sourceHandleIndex = 0;
+        let label = `${sourceTable}To${TargetTable}`;
+        let EdgeID = `${sourceTable}-${sourceColumn}-to-${TargetTable}`;
+        fields.forEach((field, idx) => {
+          if(field.label === sourceColumn)
+          {
+            sourceHandleIndex = idx;
+            if(fields[idx])
+            {
+              fields[idx].relationName = label;
+              fields[idx].kind = "object";
+            }
+          }
+        });
+
+        edges.push({
+          id: EdgeID,
+          source: sourceTable,
+          target: TargetTable,
+          sourceHandle: "field-" + sourceHandleIndex,
+          targetHandle: "table-input",
+          label: label,
+          type: "smoothstep",
+          animated: true,
+          data: {
+            relationshipType: "many-to-one",
+            fromField: sourceColumn,
+            fromTable: sourceTable,
+            isList: false
+          }
+        });
+      }
+    });
+
+    // Create node
+    nodes.push({
+      id: tableName,
+      type: "default",
+      data: {
+        label: tableName,
+        fields,
+      },
+      position: { x: 0, y: 0 },
+      style: {
+        width: calcTableWidth(fields),
+      },
+    });
+  });
+
+  return { nodes, edges };
+};
+
+/**
+ * Helper function to pluralize table names for relationship fields
+ */
+function pluralize(str: string): string {
+  if (str.endsWith("s")) return str;
+
+  if (str.endsWith("y")) {
+    const beforeY = str[str.length - 2];
+    if (beforeY && ["a", "e", "i", "o", "u"].includes(beforeY.toLowerCase())) {
+      return `${str}s`;
+    }
+    return `${str.slice(0, -1)}ies`;
+  }
+
+  return `${str}s`;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,6 +11,7 @@ import { selectDB } from "./cmd/select-db";
 import { genDrizzleERD } from "./generators/gen-drizzle-erd";
 import { genPrismaERD } from "./generators/gen-prisma-erd";
 import { genTypeORMERD } from "./generators/gen-typeorm-erd";
+import { genMySQLERD } from "./generators/gen-mysql-erd";
 import { createServer } from "./lib/create-server";
 import type { DatabaseType } from "./types/db.type";
 import type { ErdResult } from "./types/erd.type";
@@ -75,10 +76,13 @@ export const main = async () => {
       erdResult = await genPrismaERD(schemaFilePath);
     } else if (databaseType === "typeorm") {
       erdResult = await genTypeORMERD(schemaFilePath);
+    } else if (databaseType === "mysql") {
+      erdResult = await genMySQLERD(schemaFilePath);
     }
   } catch (e) {
     s2.stop("ERD generation failed");
-    cancel(`Error generating ERD: ${e instanceof Error ? e.message : "Unknown error"}`);
+    console.log(e);
+    cancel(`Error generating ERD: ${e instanceof Error ? e : "Unknown error"}`);
     return process.exit(1);
   }
 

--- a/www/app/lib/roadmap.ts
+++ b/www/app/lib/roadmap.ts
@@ -37,7 +37,7 @@ export const ROADMAP: RoadmapItem[] = [
 		title: "Database Support",
 		subFeatures: [
 			{ title: "Postgres", status: "not started" },
-			{ title: "MySQL", status: "not started" },
+			{ title: "MySQL", status: "done" },
 			{ title: "SQLite", status: "not started" },
 		],
 		priority: "P2", // Depends on ORM parsing


### PR DESCRIPTION
Hi
its support MySQL Schemas i used [node-sql-parser](https://www.npmjs.com/package/node-sql-parser?activeTab=readme) its complex to work and its types not updated yet but i make it work and test it with large schema  with  270 table (production schema 😮‍💨)
there another package i found [sql-ddl-to-json](https://www.npmjs.com/package/sql-ddl-to-json-schema) but its not reliable to use it with large schemas and not support many syntax but it's more easy 
> Note: in my opinion its be good if we support connect to database directly because there another developers not work just for innodb it possible work with myisam and i think its not support in ours and its more reliable
**i worked on it with ZERO AI Support Thank you**
#14 